### PR TITLE
Update nginx to 1.2.7 and remove old com.nginx service

### DIFF
--- a/files/brews/nginx.rb
+++ b/files/brews/nginx.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class Nginx < Formula
   homepage 'http://nginx.org/'
-  url 'http://nginx.org/download/nginx-1.0.14.tar.gz'
-  sha1 'f74cbda4f726327841abe06676c6034198427ce9'
-  version '1.0.14-boxen1'
+  url 'http://nginx.org/download/nginx-1.2.7.tar.gz'
+  sha1 '65309abde9d683ece737da7a354c8fae24e15ecb'
+  version '1.2.7-boxen1'
 
   depends_on 'pcre'
 
@@ -34,6 +34,7 @@ class Nginx < Formula
     args = ["--prefix=#{prefix}",
             "--with-http_ssl_module",
             "--with-pcre",
+            "--with-ipv6",
             "--with-cc-opt='-I#{HOMEBREW_PREFIX}/include'",
             "--with-ld-opt='-L#{HOMEBREW_PREFIX}/lib'",
             "--conf-path=/opt/boxen/config/nginx/nginx.conf",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,8 +49,8 @@ class nginx {
   }
 
   package { 'boxen/brews/nginx':
-    ensure => '1.0.14-boxen1',
-    notify => Service['com.boxen.nginx']
+    ensure => '1.2.7-boxen1',
+    notify => Service['dev.nginx']
   }
 
   # Remove Homebrew's nginx config to avoid confusion.
@@ -65,10 +65,5 @@ class nginx {
   service { 'dev.nginx':
     ensure  => running,
     require => Package['boxen/brews/nginx']
-  }
-
-  service { 'com.boxen.nginx': # replaced by dev.nginx
-    before => Service['dev.nginx'],
-    enable => false
   }
 }


### PR DESCRIPTION
we use nginx 1.2 and wanted to use boxen's nginx module. 

I've updated the homebrew install, and I've decided to submit the pull request in case there are others looking to do the same. The code is really insignificant, but managing multiple versions is more of whats important.

IMO, it would make sense to use the version of the service modules to match the version they are install. so puppet-nginx 1.0, and this can tag as version 1.2.0 and move up from there. If changes get too diverse. maintaining branches for each supported nginx version could be doable.
