### PR TITLE
Increase the max sizes for proxy headers and server names.

### DIFF
--- a/templates/config/nginx/nginx.conf.erb
+++ b/templates/config/nginx/nginx.conf.erb
@@ -30,6 +30,11 @@ http {
   gzip_comp_level   2;
   gzip_proxied      any;
 
+  server_names_hash_bucket_size 128;
+  server_names_hash_max_size 20000;
+  proxy_headers_hash_bucket_size 128;
+  proxy_headers_hash_max_size 20000;
+
   server {
     listen      80;
     server_name localhost;


### PR DESCRIPTION
This way nginx doesn't drop headers in the way to send requests to application servers.

/cc @wfarr
