### PR TITLE
Do not drop headers that contain underscores.

### DIFF
--- a/templates/config/nginx/nginx.conf.erb
+++ b/templates/config/nginx/nginx.conf.erb
@@ -35,6 +35,8 @@ http {
   proxy_headers_hash_bucket_size 128;
   proxy_headers_hash_max_size 20000;
 
+  underscores_in_headers on;
+
   server {
     listen      80;
     server_name localhost;


### PR DESCRIPTION
There are some common headers that use underscores, like `HTTP_X_CSRF_TOKEN` to prevent CSRF attacks.

Nginx drops these headers by default. This pull request enables the option to pass headers that include underscores.

/cc @wfarr
