### PR TITLE
Set default_server for the server that serves the static page

### DIFF
--- a/templates/config/nginx/nginx.conf.erb
+++ b/templates/config/nginx/nginx.conf.erb
@@ -38,7 +38,7 @@ http {
   underscores_in_headers on;
 
   server {
-    listen      80;
+    listen      80 default_server;
     server_name localhost;
 
     location / {


### PR DESCRIPTION
Otherwise accessing http://unknown.dev will serve a random site from sites/*.

Change /opt/boxen/config/nginx/nginx.conf like this:

```
server {
    listen 80 default_server;
    ...
}
```
