### PR TITLE
add --with-weak-etag option

### DIFF
--- a/files/brews/nginx.rb
+++ b/files/brews/nginx.rb
@@ -14,7 +14,8 @@ class Nginx < Formula
     [
       ['--with-passenger',   "Compile with support for Phusion Passenger module"],
       ['--with-webdav',      "Compile with support for WebDAV module"],
-      ['--with-gzip-static', "Compile with support for Gzip Static module"]
+      ['--with-gzip-static', "Compile with support for Gzip Static module"],
+      ['--with-weak-etag',   "Compile with support for weak ETag"]
     ]
   end
 
@@ -32,6 +33,11 @@ class Nginx < Formula
   end
 
   def install
+    if ARGV.include? '--with-weak-etag'
+      output = `cat #{File.expand_path("../nginx_weak_etag.patch", __FILE__)} | patch -p1 2>&1`
+      raise "weak-etag patch failed: #{output}" unless $?.success?
+    end
+
     args = ["--prefix=#{prefix}",
             "--with-http_ssl_module",
             "--with-pcre",

--- a/files/brews/nginx_weak_etag.patch
+++ b/files/brews/nginx_weak_etag.patch
@@ -1,0 +1,100 @@
+# HG changeset patch
+# User Aaron Peschel <aaron.peschel@gmail.com>
+# Date 1387964659 28800
+# Branch status
+# Node ID 01701ab3741a339ac80b31904ac46080835aca50
+# Parent  7e9543faf5f0a443ba605d9d483cf4721fae30a5
+Entity tags: only clear strict etags if weak ones are ok.
+
+diff -r 7e9543faf5f0 -r 01701ab3741a src/http/modules/ngx_http_addition_filter_module.c
+--- a/src/http/modules/ngx_http_addition_filter_module.c        Tue Nov 19 15:25:24 2013 +0400
++++ b/src/http/modules/ngx_http_addition_filter_module.c        Wed Dec 25 01:44:19 2013 -0800
+@@ -121,7 +121,7 @@
+
+     ngx_http_clear_content_length(r);
+     ngx_http_clear_accept_ranges(r);
+-    ngx_http_clear_etag(r);
++    ngx_http_clear_strict_etag(r);
+
+     return ngx_http_next_header_filter(r);
+ }
+diff -r 7e9543faf5f0 -r 01701ab3741a src/http/modules/ngx_http_gunzip_filter_module.c
+--- a/src/http/modules/ngx_http_gunzip_filter_module.c  Tue Nov 19 15:25:24 2013 +0400
++++ b/src/http/modules/ngx_http_gunzip_filter_module.c  Wed Dec 25 01:44:19 2013 -0800
+@@ -165,7 +165,7 @@
+
+     ngx_http_clear_content_length(r);
+     ngx_http_clear_accept_ranges(r);
+-    ngx_http_clear_etag(r);
++    ngx_http_clear_strict_etag(r);
+
+     return ngx_http_next_header_filter(r);
+ }
+diff -r 7e9543faf5f0 -r 01701ab3741a src/http/modules/ngx_http_gzip_filter_module.c
+--- a/src/http/modules/ngx_http_gzip_filter_module.c    Tue Nov 19 15:25:24 2013 +0400
++++ b/src/http/modules/ngx_http_gzip_filter_module.c    Wed Dec 25 01:44:19 2013 -0800
+@@ -306,7 +306,7 @@
+
+     ngx_http_clear_content_length(r);
+     ngx_http_clear_accept_ranges(r);
+-    ngx_http_clear_etag(r);
++    ngx_http_clear_strict_etag(r);
+
+     return ngx_http_next_header_filter(r);
+ }
+diff -r 7e9543faf5f0 -r 01701ab3741a src/http/modules/ngx_http_ssi_filter_module.c
+--- a/src/http/modules/ngx_http_ssi_filter_module.c     Tue Nov 19 15:25:24 2013 +0400
++++ b/src/http/modules/ngx_http_ssi_filter_module.c     Wed Dec 25 01:44:19 2013 -0800
+@@ -361,7 +361,7 @@
+         ngx_http_clear_content_length(r);
+         ngx_http_clear_last_modified(r);
+         ngx_http_clear_accept_ranges(r);
+-        ngx_http_clear_etag(r);
++        ngx_http_clear_strict_etag(r);
+     }
+
+     return ngx_http_next_header_filter(r);
+diff -r 7e9543faf5f0 -r 01701ab3741a src/http/modules/ngx_http_sub_filter_module.c
+--- a/src/http/modules/ngx_http_sub_filter_module.c     Tue Nov 19 15:25:24 2013 +0400
++++ b/src/http/modules/ngx_http_sub_filter_module.c     Wed Dec 25 01:44:19 2013 -0800
+@@ -168,7 +168,7 @@
+     if (r == r->main) {
+         ngx_http_clear_content_length(r);
+         ngx_http_clear_last_modified(r);
+-        ngx_http_clear_etag(r);
++        ngx_http_clear_strict_etag(r);
+     }
+
+     return ngx_http_next_header_filter(r);
+diff -r 7e9543faf5f0 -r 01701ab3741a src/http/modules/ngx_http_xslt_filter_module.c
+--- a/src/http/modules/ngx_http_xslt_filter_module.c    Tue Nov 19 15:25:24 2013 +0400
++++ b/src/http/modules/ngx_http_xslt_filter_module.c    Wed Dec 25 01:44:19 2013 -0800
+@@ -328,7 +328,7 @@
+         }
+
+         ngx_http_clear_last_modified(r);
+-        ngx_http_clear_etag(r);
++        ngx_http_clear_strict_etag(r);
+     }
+
+     rc = ngx_http_next_header_filter(r);
+diff -r 7e9543faf5f0 -r 01701ab3741a src/http/ngx_http_core_module.h
+--- a/src/http/ngx_http_core_module.h   Tue Nov 19 15:25:24 2013 +0400
++++ b/src/http/ngx_http_core_module.h   Wed Dec 25 01:44:19 2013 -0800
+@@ -579,5 +579,16 @@
+         r->headers_out.etag = NULL;                                           \
+     }
+
++#define ngx_http_clear_strict_etag(r)                                         \
++                                                                              \
++    if (r->headers_out.etag                                                   \
++        && (r->headers_out.etag->value.len < 2                                \
++            || r->headers_out.etag->value.data[0] != 'W'                      \
++            || r->headers_out.etag->value.data[1] != '/'))                    \
++    {                                                                         \
++        r->headers_out.etag->hash = 0;                                        \
++        r->headers_out.etag = NULL;                                           \
++    }
++
+
+ #endif /* _NGX_HTTP_CORE_H_INCLUDED_ */

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,10 @@ class nginx(
         before => Package['boxen/brews/nginx'],
       }
 
+      file { "${homebrew::config::tapsdir}/boxen-brews/nginx_weak_etag.patch":
+        source  => "puppet:///modules/nginx/brews/nginx_weak_etag.patch",
+      }
+
       package { 'boxen/brews/nginx':
         ensure => '1.4.4-boxen1',
         notify => Service['dev.nginx']


### PR DESCRIPTION
This fixes http://forum.nginx.org/read.php?2,240120,240120 / https://code.google.com/p/phusion-passenger/issues/detail?id=903 / http://trac.nginx.org/nginx/ticket/377 by passing through weak etags.
Weak etag can be generated in rails/rack apps using http://stackoverflow.com/questions/18693718/weak-etags-in-rails/21003624#21003624

The nginx team seems to be unwilling to accept our patch or do anything about this issue since a few months now. This may make it into nginx eventually, but we think having etags is a pretty vital feature for a webserver so we patched it in.

Can be activated using:
```
Package <| title == "boxen/brews/nginx" |> {
    install_options => ["--with-passenger", "--with-weak-etag"],
    require => File["/opt/boxen/homebrew/Library/ENV/4.3/passenger-config"]
  }
```
(see https://github.com/boxen/puppet-nginx/issues/6 for full passenger instructions)

@fromonesrc @rafaelfranca

