### PR TITLE
do not declare success and exit when install fails since it is invisible from boxen

### DIFF
--- a/files/brews/nginx.rb
+++ b/files/brews/nginx.rb
@@ -19,16 +19,15 @@ class Nginx < Formula
   end
 
   def passenger_config_args
-      passenger_root = `passenger-config --root`.chomp
+    passenger_root = `passenger-config --root`.chomp
 
-      if File.directory?(passenger_root)
-        return "--add-module=#{passenger_root}/ext/nginx"
-      end
+    if File.directory?(passenger_root)
+      return "--add-module=#{passenger_root}/ext/nginx"
+    end
 
-      puts "Unable to install nginx with passenger support. The passenger"
-      puts "gem must be installed and passenger-config must be in your path"
-      puts "in order to continue."
-      exit
+    raise "Unable to install nginx with passenger support. The passenger " +
+      "gem must be installed and passenger-config must be in your path " +
+      "in order to continue."
   end
 
   def install


### PR DESCRIPTION
nginx package install just said "Created" but nginx did not get installed and did not fail and did not show any message, took me a while to figure out what was going on ...

@fromonesrc @rafaelfranca
