### PR TITLE
fix nginx compile error unable to include common/AgentStarter.h

### DIFF
--- a/files/brews/nginx.rb
+++ b/files/brews/nginx.rb
@@ -19,10 +19,10 @@ class Nginx < Formula
   end
 
   def passenger_config_args
-      passenger_root = `passenger-config --root`.chomp
+      @passenger_root = `passenger-config --root`.chomp
 
-      if File.directory?(passenger_root)
-        return "--add-module=#{passenger_root}/ext/nginx"
+      if File.directory?(@passenger_root)
+        return "--add-module=#{@passenger_root}/ext/nginx"
       end
 
       puts "Unable to install nginx with passenger support. The passenger"
@@ -47,6 +47,7 @@ class Nginx < Formula
     args << "--with-http_gzip_static_module" if ARGV.include? '--with-gzip-static'
 
     system "./configure", *args
+    system "cp -R #{@passenger_root}/ext/* src/core"
     system "make"
     system "make install"
     man8.install "objs/nginx.8"


### PR DESCRIPTION
this is not very pretty, but maybe it's a help for someone else running into the same issue...

```
==> ./configure --prefix=/opt/boxen/homebrew/Cellar/nginx/1.4.4-boxen1 --with-http_ssl_module --with-pcre --with-ipv6 --with-cc-opt='-I/opt/boxen/homebrew/include' --with-ld-opt='-L/opt/boxen/homebrew/lib' --conf-path=/opt/boxen/config/nginx/nginx.conf --pid-path=/opt/boxen/data/nginx/nginx.pid --lock-path=/opt/boxen/data/nginx/nginx.lock --add-module=/opt/boxen/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/passenger-4.0.27/ext/nginx
==> make
#include "common/AgentsStarter.h"
         ^
1 error generated.
make[1]: *** [objs/addon/nginx/ngx_http_passenger_module.o] Error 1
make: *** [build] Error 2
```

I tried adding
`-I/opt/boxen/rbenv/versions/2.0.0/lib/ruby/gems/2.0.0/gems/passenger-4.0.27/ext` (folder of common/AgentsStarter.h) to the build options but that did not help ...
