### PR TITLE
Add force option when removing folders

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ class nginx(
         $nginx::config::sitesdir
       ]:
         ensure => absent,
-        force => true,
+        force  => true,
       }
 
       package { 'boxen/brews/nginx':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,8 @@ class nginx(
         $nginx::config::logdir,
         $nginx::config::sitesdir
       ]:
-        ensure => absent
+        ensure => absent,
+        force => true,
       }
 
       package { 'boxen/brews/nginx':


### PR DESCRIPTION
The folders aren't deleting and we have annoying lines in the output: 

```
Notice: /Stage[main]/Nginx/File[/opt/boxen/config/nginx]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Nginx/File[/opt/boxen/config/nginx]/ensure: removed
Notice: /Stage[main]/Nginx/File[/opt/boxen/config/nginx/sites]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Nginx/File[/opt/boxen/config/nginx/sites]/ensure: removed
Notice: /Stage[main]/Nginx/File[/opt/boxen/data/nginx]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Nginx/File[/opt/boxen/data/nginx]/ensure: removed
Notice: /Stage[main]/Nginx/File[/opt/boxen/log/nginx]: Not removing directory; use 'force' to override
Notice: /Stage[main]/Nginx/File[/opt/boxen/log/nginx]/ensure: removed
```
