### PR TITLE
Add application/x-navimap content type

### DIFF
--- a/files/config/nginx/mime.types
+++ b/files/config/nginx/mime.types
@@ -70,4 +70,5 @@ types {
     video/x-ms-asf                        asx asf;
     video/x-ms-wmv                        wmv;
     video/x-msvideo                       avi;
+    application/x-navimap                 map;
 }


### PR DESCRIPTION
Add application/x-navimap content type. I needed this to set up source maps in Sass.
