### PR TITLE
Update JS mime type

### DIFF
--- a/files/config/nginx/mime.types
+++ b/files/config/nginx/mime.types
@@ -4,7 +4,7 @@ types {
     text/xml                              xml;
     image/gif                             gif;
     image/jpeg                            jpeg jpg;
-    application/x-javascript              js;
+    application/javascript                js;
     application/atom+xml                  atom;
     application/rss+xml                   rss;
 


### PR DESCRIPTION
`application/x-javascript` has been obsoleted by `application/javascript` for a while now.

/cc @dgoodlad 
