### PR TITLE
Depend on the Homebrew installed OpenSSL library

### DIFF
--- a/files/brews/nginx.rb
+++ b/files/brews/nginx.rb
@@ -4,7 +4,7 @@ class Nginx < Formula
   homepage 'http://nginx.org/'
   url 'http://nginx.org/download/nginx-1.6.2.tar.gz'
   sha1 '1a5458bc15acf90eea16353a1dd17285cf97ec35'
-  version '1.6.2-boxen1'
+  version '1.6.2-boxen2'
 
   depends_on 'pcre'
 
@@ -17,6 +17,9 @@ class Nginx < Formula
       ['--with-gzip-static', "Compile with support for Gzip Static module"]
     ]
   end
+
+  depends_on "pcre"
+  depends_on "openssl" => :recommended
 
   def passenger_config_args
       passenger_root = `passenger-config --root`.chomp
@@ -32,12 +35,17 @@ class Nginx < Formula
   end
 
   def install
+    pcre = Formula["pcre"]
+    openssl = Formula["openssl"]
+    cc_opt = "-I#{pcre.include} -I#{openssl.include}"
+    ld_opt = "-L#{pcre.lib} -L#{openssl.lib}"
+
     args = ["--prefix=#{prefix}",
             "--with-http_ssl_module",
             "--with-pcre",
             "--with-ipv6",
-            "--with-cc-opt='-I#{HOMEBREW_PREFIX}/include'",
-            "--with-ld-opt='-L#{HOMEBREW_PREFIX}/lib'",
+            "--with-cc-opt=#{cc_opt}",
+            "--with-ld-opt=#{ld_opt}",
             "--conf-path=/opt/boxen/config/nginx/nginx.conf",
             "--pid-path=/opt/boxen/data/nginx/nginx.pid",
             "--lock-path=/opt/boxen/data/nginx/nginx.lock"]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class nginx(
       }
 
       package { 'boxen/brews/nginx':
-        ensure => '1.6.2-boxen1',
+        ensure => '1.6.2-boxen2',
         notify => Service['dev.nginx']
       }
 

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -41,7 +41,7 @@ describe 'nginx' do
       with_before('Package[boxen/brews/nginx]')
 
     should contain_package('boxen/brews/nginx').with({
-      :ensure => '1.6.2-boxen1',
+      :ensure => '1.6.2-boxen2',
       :notify => 'Service[dev.nginx]'
     })
 


### PR DESCRIPTION
OS X 10.11 El Capitan does not include OpenSSL headers. To support this Mac version we need to depend on the Homebrew-installed OpenSSL library.