### PR TITLE
Allow specifying another port instead of 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Status](https://travis-ci.org/boxen/puppet-nginx.svg?branch=master)](https://tra
 include nginx
 ```
 
+To specify a different port than 80:
+```puppet
+class { "nginx":
+    port => 8080
+}
+```
+
 ## Required Puppet Modules
 
 * boxen

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,7 @@
 #
 class nginx(
   $ensure = present,
+  $port = 80,
 ) {
   include nginx::config
   include homebrew

--- a/templates/config/nginx/nginx.conf.erb
+++ b/templates/config/nginx/nginx.conf.erb
@@ -38,7 +38,7 @@ http {
   underscores_in_headers on;
 
   server {
-    listen      80 default_server;
+    listen      <%= @port %> default_server;
     server_name localhost;
 
     location / {


### PR DESCRIPTION
This fixes issue https://github.com/boxen/puppet-nginx/issues/38 by giving the option to specify a different port than 80 for the very friendly little default one-page site defined [here](https://github.com/boxen/puppet-nginx/blob/master/manifests/init.pp#L44).

Default is still port 80.