### PR TITLE
Updates nginx Formula for 1.12.1 Release

### DIFF
--- a/files/brews/nginx.rb
+++ b/files/brews/nginx.rb
@@ -1,67 +1,206 @@
 require 'formula'
 
 class Nginx < Formula
-  homepage 'https://nginx.org/'
-  url 'https://nginx.org/download/nginx-1.10.2.tar.gz'
-  sha256 '1045ac4987a396e2fa5d0011daf8987b612dd2f05181b67507da68cbe7d765c2'
-  version '1.10.2-boxen1'
+  desc "HTTP(S) server and reverse proxy, and IMAP/POP3 proxy server"
+  homepage "https://nginx.org/"
+  url "https://nginx.org/download/nginx-1.12.1.tar.gz"
+  sha256 "8793bf426485a30f91021b6b945a9fd8a84d87d17b566562c3797aba8fac76fb"
+  version '1.12.1-boxen1'
 
-  depends_on 'pcre'
+  head "http://hg.nginx.org/nginx/", :using => :hg
 
-  skip_clean 'logs'
-
-  def options
-    [
-      ['--with-passenger',   "Compile with support for Phusion Passenger module"],
-      ['--with-webdav',      "Compile with support for WebDAV module"],
-      ['--with-gzip-static', "Compile with support for Gzip Static module"],
-      ['--with-http2',       "Compile with support for the HTTP/2 module"],
-    ]
+  bottle do
+    sha256 "93bcf8e3aec465c219b6c0b4f4d5437c61bf00f2a930ef5702e0521edc51f20e" => :sierra
+    sha256 "8a7c3580534aa0854927f750d4f044a2a85f90d4c1936338a4a09fef7db0824e" => :el_capitan
+    sha256 "0caae754f402abbe1eca413a7f0291fe2499d5779bb1e537d7f80a4d7d3156d3" => :yosemite
   end
 
+  devel do
+    url "https://nginx.org/download/nginx-1.13.3.tar.gz"
+    sha256 "5b73f98004c302fb8e4a172abf046d9ce77739a82487e4873b39f9b0dcbb0d72"
+  end
+
+  # Before submitting more options to this formula please check they aren't
+  # already in Homebrew/homebrew-nginx/nginx-full:
+  # https://github.com/Homebrew/homebrew-nginx/blob/master/Formula/nginx-full.rb
+  option "with-passenger", "Compile with support for Phusion Passenger module"
+  option "with-webdav", "Compile with support for WebDAV module"
+  option "with-debug", "Compile with support for debug log"
+  option "with-gunzip", "Compile with support for gunzip module"
+
   depends_on "pcre"
-  depends_on "openssl" => :recommended
+  depends_on "passenger" => :optional
 
-  def passenger_config_args
-      passenger_root = `passenger-config --root`.chomp
-
-      if File.directory?(passenger_root)
-        return "--add-module=#{passenger_root}/ext/nginx"
-      end
-
-      puts "Unable to install nginx with passenger support. The passenger"
-      puts "gem must be installed and passenger-config must be in your path"
-      puts "in order to continue."
-      exit
+  # passenger uses apr, which uses openssl, so need to keep
+  # crypto library choice consistent throughout the tree.
+  if build.with? "passenger"
+    depends_on "openssl"
+  else
+    depends_on "openssl@1.1"
   end
 
   def install
+    # Changes default port to 8080
+    inreplace "conf/nginx.conf" do |s|
+      s.gsub! "listen       80;", "listen       8080;"
+      s.gsub! "    #}\n\n}", "    #}\n    include servers/*;\n}"
+    end
+
     pcre = Formula["pcre"]
-    openssl = Formula["openssl"]
-    cc_opt = "-I#{pcre.include} -I#{openssl.include}"
-    ld_opt = "-L#{pcre.lib} -L#{openssl.lib}"
 
-    args = ["--prefix=#{prefix}",
-            "--with-http_ssl_module",
-            "--with-pcre",
-            "--with-ipv6",
-            "--with-cc-opt=#{cc_opt}",
-            "--with-ld-opt=#{ld_opt}",
-            "--conf-path=/opt/boxen/config/nginx/nginx.conf",
-            "--pid-path=/opt/boxen/data/nginx/nginx.pid",
-            "--lock-path=/opt/boxen/data/nginx/nginx.lock"]
+    if build.with? "passenger"
+      openssl = Formula["openssl"]
+    else
+      openssl = Formula["openssl@1.1"]
+    end
 
-    args << passenger_config_args if ARGV.include? '--with-passenger'
-    args << "--with-http_dav_module" if ARGV.include? '--with-webdav'
-    args << "--with-http_gzip_static_module" if ARGV.include? '--with-gzip-static'
-    args << "--with-http_v2_module" if ARGV.include? "--with-http2"
+    cc_opt = "-I#{pcre.opt_include} -I#{openssl.opt_include}"
+    ld_opt = "-L#{pcre.opt_lib} -L#{openssl.opt_lib}"
 
-    system "./configure", *args
-    system "make"
-    system "make install"
-    man8.install "objs/nginx.8"
+    args = %W[
+      --prefix=#{prefix}
+      --with-http_ssl_module
+      --with-pcre
+      --sbin-path=#{bin}/nginx
+      --with-cc-opt=#{cc_opt}
+      --with-ld-opt=#{ld_opt}
+      --conf-path=#{etc}/nginx/nginx.conf
+      --pid-path=#{var}/run/nginx.pid
+      --lock-path=#{var}/run/nginx.lock
+      --http-client-body-temp-path=#{var}/run/nginx/client_body_temp
+      --http-proxy-temp-path=#{var}/run/nginx/proxy_temp
+      --http-fastcgi-temp-path=#{var}/run/nginx/fastcgi_temp
+      --http-uwsgi-temp-path=#{var}/run/nginx/uwsgi_temp
+      --http-scgi-temp-path=#{var}/run/nginx/scgi_temp
+      --http-log-path=#{var}/log/nginx/access.log
+      --error-log-path=#{var}/log/nginx/error.log
+      --with-http_gzip_static_module
+      --with-http_v2_module
+    ]
 
-    # remove unnecessary config files
-    system "rm -rf #{etc}/nginx"
+    if build.with? "passenger"
+      nginx_ext = `#{Formula["passenger"].opt_bin}/passenger-config --nginx-addon-dir`.chomp
+      args << "--add-module=#{nginx_ext}"
+    end
+
+    args << "--with-http_dav_module" if build.with? "webdav"
+    args << "--with-debug" if build.with? "debug"
+    args << "--with-http_gunzip_module" if build.with? "gunzip"
+
+    if build.head?
+      system "./auto/configure", *args
+    else
+      system "./configure", *args
+    end
+
+    system "make", "install"
+    if build.head?
+      man8.install "docs/man/nginx.8"
+    else
+      man8.install "man/nginx.8"
+    end
+  end
+
+  def post_install
+    (etc/"nginx/servers").mkpath
+    (var/"run/nginx").mkpath
+
+    # nginx's docroot is #{prefix}/html, this isn't useful, so we symlink it
+    # to #{HOMEBREW_PREFIX}/var/www. The reason we symlink instead of patching
+    # is so the user can redirect it easily to something else if they choose.
+    html = prefix/"html"
+    dst = var/"www"
+
+    if dst.exist?
+      html.rmtree
+      dst.mkpath
+    else
+      dst.dirname.mkpath
+      html.rename(dst)
+    end
+
+    prefix.install_symlink dst => "html"
+
+    # for most of this formula's life the binary has been placed in sbin
+    # and Homebrew used to suggest the user copy the plist for nginx to their
+    # ~/Library/LaunchAgents directory. So we need to have a symlink there
+    # for such cases
+    if rack.subdirs.any? { |d| d.join("sbin").directory? }
+      sbin.install_symlink bin/"nginx"
+    end
+  end
+
+  def passenger_caveats; <<-EOS.undent
+    To activate Phusion Passenger, add this to #{etc}/nginx/nginx.conf, inside the 'http' context:
+      passenger_root #{Formula["passenger"].opt_libexec}/src/ruby_supportlib/phusion_passenger/locations.ini;
+      passenger_ruby /usr/bin/ruby;
+    EOS
+  end
+
+  def caveats
+    s = <<-EOS.undent
+    Docroot is: #{var}/www
+
+    The default port has been set in #{etc}/nginx/nginx.conf to 8080 so that
+    nginx can run without sudo.
+
+    nginx will load all files in #{etc}/nginx/servers/.
+    EOS
+    s << "\n" << passenger_caveats if build.with? "passenger"
+    s
+  end
+
+  plist_options :manual => "nginx"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <false/>
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{opt_bin}/nginx</string>
+            <string>-g</string>
+            <string>daemon off;</string>
+        </array>
+        <key>WorkingDirectory</key>
+        <string>#{HOMEBREW_PREFIX}</string>
+      </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    (testpath/"nginx.conf").write <<-EOS
+      worker_processes 4;
+      error_log #{testpath}/error.log;
+      pid #{testpath}/nginx.pid;
+
+      events {
+        worker_connections 1024;
+      }
+
+      http {
+        client_body_temp_path #{testpath}/client_body_temp;
+        fastcgi_temp_path #{testpath}/fastcgi_temp;
+        proxy_temp_path #{testpath}/proxy_temp;
+        scgi_temp_path #{testpath}/scgi_temp;
+        uwsgi_temp_path #{testpath}/uwsgi_temp;
+
+        server {
+          listen 8080;
+          root #{testpath};
+          access_log #{testpath}/access.log;
+          error_log #{testpath}/error.log;
+        }
+      }
+    EOS
+    system bin/"nginx", "-t", "-c", testpath/"nginx.conf"
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@ class nginx(
       }
 
       package { 'boxen/brews/nginx':
-        ensure          => '1.10.2-boxen1',
+        ensure          => '1.12.1-boxen1',
         install_options => [
           '--with-http2',
         ],

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -41,7 +41,7 @@ describe 'nginx' do
       with_before('Package[boxen/brews/nginx]')
 
     should contain_package('boxen/brews/nginx').with({
-      :ensure => '1.10.2-boxen1',
+      :ensure => '1.12.1-boxen1',
       :notify => 'Service[dev.nginx]'
     })
 


### PR DESCRIPTION
This PR proposes to update the nginx formula so the module installs nginx 1.12.1 instead of 1.10.2. This was motivated by issues on El Capitan machines with SIP enabled erroring out on installation.

If I have any reluctance about this, it's because I don't understand the how and why of the custom formula. If it's about "pinning" the specific version, then this should be okay. If there are more subtle, Puppet- or Boxen-specific tweaks that need to be made, then this may not be okay. (If it's about neither of these, why not just use the Homebrew provider? 🤔)

I'd be deeply grateful for any insight into this. The custom formulae in different modules have long perplexed me!